### PR TITLE
Use browserslist's best practicies

### DIFF
--- a/template/.babelrc
+++ b/template/.babelrc
@@ -2,13 +2,6 @@
   "presets": [
     [
       "env",
-    {
-      "targets": {
-        "browsers": [
-          "last 2 versions"
-        ]
-      }
-    }
     ]
   ],
   "plugins": [

--- a/template/package.json
+++ b/template/package.json
@@ -149,5 +149,10 @@
   "license": {
     "type": "MIT",
     "url": "http://www.opensource.org/licenses/mit-license.php"
-  }
+  },
+  "browserslist": [
+    "> 0.5%",
+    "last 2 versions",
+    "Firefox ESR"
+  ]
 }

--- a/template/package.json
+++ b/template/package.json
@@ -151,8 +151,6 @@
     "url": "http://www.opensource.org/licenses/mit-license.php"
   },
   "browserslist": [
-    "> 0.5%",
-    "last 2 versions",
-    "Firefox ESR"
+    "last 2 versions"
   ]
 }


### PR DESCRIPTION
Move browserslist option from .babelrc to package.json because it is [recommended way](https://github.com/browserslist/browserslist#queries).
It allows different tools (babel, autoprefixer, cssnext, cssnano) to use the same config.